### PR TITLE
fix: prevent backup file accumulation during frequent sync operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.1.3] - 2025-07-08
+
+### Changed
+- **Backup creation disabled by default** - Prevents backup file accumulation during frequent sync operations
+- **Added backup configuration options** - `createBackups` and `maxBackups` security settings
+
+### Added
+- Backup cleanup mechanism when backups are enabled
+- Performance information logging for sync scenarios
+
 ## [2.1.2] - 2025-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -107,22 +107,26 @@ export type DecryptFunction<T> = (encrypted: string) => Promise<T[]>;
 
 export interface SecurityOptions {
   /** Whether to enforce encryption (throw error if encrypt/decrypt not provided) */
-  enforceEncryption?: boolean;
+  enforceEncryption: boolean;
   /** Whether to allow fallback to plaintext on decryption failure */
-  allowPlaintextFallback?: boolean;
+  allowPlaintextFallback: boolean;
   /** Whether to validate decrypted data structure */
-  validateDecryptedData?: boolean;
+  validateDecryptedData: boolean;
   /** Whether callback errors should propagate */
-  propagateCallbackErrors?: boolean;
+  propagateCallbackErrors: boolean;
   /** Custom data validator function */
-  dataValidator?: <T>(data: unknown) => data is T[];
+  dataValidator: <T>(data: unknown) => data is T[];
+  /** Whether to create backup files on save (default: false for sync scenarios) */
+  createBackups: boolean;
+  /** Maximum number of backup files to keep (default: 5) */
+  maxBackups: number;
 }
 
 export interface AdapterOptions<T> {
   base_dir?: import('@tauri-apps/plugin-fs').BaseDirectory;
   encrypt?: EncryptFunction<T>;
   decrypt?: DecryptFunction<T>;
-  security?: SecurityOptions;
+  security?: Partial<SecurityOptions>;
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitzzahh/signaldb-adapter-tauri",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A SignalDB persistence adapter for Tauri apps with optional encryption support",
   "module": "dist/index.js",
   "type": "module",

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,10 @@ export interface SecurityOptions {
   propagateCallbackErrors?: boolean;
   /** Custom data validator function */
   dataValidator?: <T>(data: unknown) => data is T[];
+  /** Whether to create backup files on save (default: false for sync scenarios) */
+  createBackups?: boolean;
+  /** Maximum number of backup files to keep (default: 5) */
+  maxBackups?: number;
 }
 
 export interface AdapterOptions<T> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,24 +3,24 @@ export type DecryptFunction<T> = (encrypted: string) => Promise<T[]>;
 
 export interface SecurityOptions {
   /** Whether to enforce encryption (throw error if encrypt/decrypt not provided) */
-  enforceEncryption?: boolean;
+  enforceEncryption: boolean;
   /** Whether to allow fallback to plaintext on decryption failure */
-  allowPlaintextFallback?: boolean;
+  allowPlaintextFallback: boolean;
   /** Whether to validate decrypted data structure */
-  validateDecryptedData?: boolean;
+  validateDecryptedData: boolean;
   /** Whether callback errors should propagate */
-  propagateCallbackErrors?: boolean;
+  propagateCallbackErrors: boolean;
   /** Custom data validator function */
-  dataValidator?: <T>(data: unknown) => data is T[];
+  dataValidator: <T>(data: unknown) => data is T[];
   /** Whether to create backup files on save (default: false for sync scenarios) */
-  createBackups?: boolean;
+  createBackups: boolean;
   /** Maximum number of backup files to keep (default: 5) */
-  maxBackups?: number;
+  maxBackups: number;
 }
 
 export interface AdapterOptions<T> {
   base_dir?: import('@tauri-apps/plugin-fs').BaseDirectory;
   encrypt?: EncryptFunction<T>;
   decrypt?: DecryptFunction<T>;
-  security?: SecurityOptions;
+  security?: Partial<SecurityOptions>;
 }


### PR DESCRIPTION
### Changed
- **Backup creation disabled by default** - Prevents backup file accumulation during frequent sync operations
- **Added backup configuration options** - `createBackups` and `maxBackups` security settings

### Added
- Backup cleanup mechanism when backups are enabled
- Performance information logging for sync scenarios